### PR TITLE
Fixed typo that made avr-binutils compile fail on lion

### DIFF
--- a/avr-binutils.rb
+++ b/avr-binutils.rb
@@ -11,7 +11,7 @@ class AvrBinutils < Formula
   def install
 
     if MacOS.version == :lion
-      ENV['CC'] = '#{ENV.cc}'
+      ENV['CC'] = ENV.cc
     end
 
     ENV['CPPFLAGS'] = "-I#{include}"
@@ -39,7 +39,7 @@ class AvrBinutils < Formula
     ENV.delete 'CXX'
 
     if MacOS.version == :lion
-      ENV['CC'] = '#{ENV.cc}'
+      ENV['CC'] = ENV.cc
     end
 
     system "./configure", "--target=avr", *args


### PR DESCRIPTION
avr-binutils configure was failing on lion:
checking for gcc... **#{ENV.cc}**
checking for C compiler default output file name... 
configure: error: in `/private/tmp/avr-binutils-dElB/binutils-2.23.1':
configure: error: C compiler cannot create executables

Removed single quotes around env variables.
