### PR TITLE
Changed checksums from MD5 to SHA1

### DIFF
--- a/avr-gcc.rb
+++ b/avr-gcc.rb
@@ -10,7 +10,7 @@ end
 class AvrGcc < Formula
   homepage 'http://gcc.gnu.org'
   url 'http://ftp.gnu.org/gnu/gcc/gcc-4.7.2/gcc-4.7.2.tar.bz2'
-  md5 'cc308a0891e778cfda7a151ab8a6e762'
+  sha1 'a464ba0f26eef24c29bcd1e7489421117fb9ee35'
 
   depends_on 'larsimmisch/avr/avr-binutils'
   depends_on 'gmp'
@@ -84,5 +84,3 @@ class AvrGcc < Formula
     end
   end
 end
-
- 

--- a/avr-libc.rb
+++ b/avr-libc.rb
@@ -3,7 +3,7 @@ require 'formula'
 class AvrLibc < Formula
   url 'http://download.savannah.gnu.org/releases/avr-libc/avr-libc-1.8.0.tar.bz2'
   homepage 'http://www.nongnu.org/avr-libc/'
-  md5 '54c71798f24c96bab206be098062344f'
+  sha1 '2e3815221be8e22f5f2c07b922ce92ecfa85bade'
 
   depends_on 'larsimmisch/avr/avr-gcc'
 
@@ -26,4 +26,3 @@ class AvrLibc < Formula
     cp_r avr, avr_gcc.prefix
   end
 end
-


### PR DESCRIPTION
MD5 support is deprecated and will be removed in a future version of homebrew.
See https://github.com/mxcl/homebrew/pull/17317
